### PR TITLE
Fix generated type declarations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ const { RawSource, SourceMapSource } = webpack.sources;
 
 const isJsFile = /\.[cm]?js(\?.*)?$/i;
 
-module.exports = class SwcMinifyWebpackPlugin {
+class SwcMinifyWebpackPlugin {
   private readonly options: JsMinifyOptions = {
     compress: true,
     mangle: true,
@@ -105,3 +105,4 @@ module.exports = class SwcMinifyWebpackPlugin {
     );
   }
 };
+export = SwcMinifyWebpackPlugin


### PR DESCRIPTION
Fix the generated type declarations.

By using TypeScript's special `export =` we're able to author source
that mostly looks like ESM but generates our desired declaration and js
output.

The published type declarations are currently `export {}`, which makes
it hard to use this package in typechecked files.

After this change, the generated JS file is mostly the same, but the
declaration file has the expected output:

```ts
import { JsMinifyOptions } from '@swc/core';
import webpack from 'webpack';
declare class SwcMinifyWebpackPlugin {
    private readonly options;
    constructor(options?: JsMinifyOptions);
    apply(compiler: webpack.Compiler): void;
    private transformAssets;
    private processAssets;
}
export = SwcMinifyWebpackPlugin;
```

Another change that may be helpful to use a shared tsconfig designed for
node, for example:

https://github.com/tsconfig/bases#node-lts--strictest-tsconfigjson

That will likely improve the build result and save generating
compatibility code that's not necessary for targeting Node.

I'd be happy to push that here or in another PR.
