### PR TITLE
Fix compilation with source maps for empty assets

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,11 +82,11 @@ export class SwcMinifyWebpackPlugin {
           sourceMap,
         });
 
-        const newSource = sourceMap
+        const newSource = sourceMap && result.map
           ? new SourceMapSource(
               result.code,
               asset.name,
-              result.map as any,
+              result.map,
               sourceAsString,
               map as any,
               true


### PR DESCRIPTION
Hello! Thank you very much for this package!

Sadly, I noticed a problem when source maps are enabled and an `asset` is empty. (This happens when using the `mini-css-extract-plugin`.)

For an empty source string, swc does not produce a source map. In that case, `result.map` is `undefined`. This is also in line with the Typescript types for `result.map`, which is `string | undefined`.

Passing `undefined` to `SourceMapSource` leads to this error:

```
undefined:1
undefined
^

SyntaxError: Unexpected token u in JSON at position 0
    at JSON.parse (<anonymous>)
    at SourceMapSource._ensureSourceMapObject (/Users/daniel/dev/node/webpack-swc-repro/node_modules/webpack-sources/lib/SourceMapSource.js:125:35)
    at SourceMapSource.sourceAndMap (/Users/daniel/dev/node/webpack-swc-repro/node_modules/webpack-sources/lib/SourceMapSource.js:182:9)
    at getTaskForFile (/Users/daniel/dev/node/webpack-swc-repro/node_modules/webpack/lib/SourceMapDevToolPlugin.js:103:30)
    at /Users/daniel/dev/node/webpack-swc-repro/node_modules/webpack/lib/SourceMapDevToolPlugin.js:291:22
    at /Users/daniel/dev/node/webpack-swc-repro/node_modules/webpack/lib/Cache.js:93:5
    at Hook.eval [as callAsync] (eval at create (/Users/daniel/dev/node/webpack-swc-repro/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:6:1)
    at Cache.get (/Users/daniel/dev/node/webpack-swc-repro/node_modules/webpack/lib/Cache.js:75:18)
    at ItemCacheFacade.get (/Users/daniel/dev/node/webpack-swc-repro/node_modules/webpack/lib/CacheFacade.js:111:15)
    at /Users/daniel/dev/node/webpack-swc-repro/node_modules/webpack/lib/SourceMapDevToolPlugin.js:242:18
```

I was able to fix the problem by checking whether `result.map` was truthy. This also allowed me to remove the `as any`, as the types now match.

This is currently a blocker for us. It would be great to see this released soon, so we can start using this package! Thanks in advance.